### PR TITLE
Update stock creation UI

### DIFF
--- a/lib/screens/add_edit_stock_page.dart
+++ b/lib/screens/add_edit_stock_page.dart
@@ -20,8 +20,9 @@ enum AssignmentType { none, warehouse, shop }
 
 class AddEditStockPage extends StatefulWidget {
   final String? existingItemId;
+  final bool showQuantityField;
 
-  const AddEditStockPage({super.key, this.existingItemId});
+  const AddEditStockPage({super.key, this.existingItemId, this.showQuantityField = true});
 
   @override
   State<AddEditStockPage> createState() => _AddEditStockPageState();
@@ -481,8 +482,9 @@ class _AddEditStockPageState extends State<AddEditStockPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CorporateHeader(
-        title:
-            widget.existingItemId == null ? 'Yeni Stok Ekle' : 'Stok Düzenle',
+        title: widget.existingItemId == null
+            ? (widget.showQuantityField ? 'Yeni Stok Ekle' : 'Stok Kartı Oluştur')
+            : 'Stok Düzenle',
         showBackButton: true,
         showSaveButton: true,
         centerTitle: true,
@@ -527,27 +529,30 @@ class _AddEditStockPageState extends State<AddEditStockPage> {
                             ? 'Stok adı zorunludur.'
                             : null),
                     const SizedBox(height: 12),
-                    TextFormField(
-                        controller: _quantityController,
-                        decoration: const InputDecoration(
-                            labelText: 'Miktar (*)',
-                            border: OutlineInputBorder()),
-                        keyboardType: TextInputType.number,
-                        inputFormatters: [
-                          FilteringTextInputFormatter.digitsOnly
-                        ],
-                        textInputAction: TextInputAction.next,
-                        validator: (v) {
-                          if (v == null || v.isEmpty) {
-                            return 'Miktar zorunludur.';
-                          }
-                          final n = int.tryParse(v);
-                          if (n == null || n < 0) {
-                            return 'Geçerli pozitif bir miktar girin.';
-                          }
-                          return null;
-                        }),
-                    const SizedBox(height: 12),
+                    if (widget.showQuantityField) ...[
+                      TextFormField(
+                          controller: _quantityController,
+                          decoration: const InputDecoration(
+                              labelText: 'Miktar (*)',
+                              border: OutlineInputBorder()),
+                          keyboardType: TextInputType.number,
+                          inputFormatters: [
+                            FilteringTextInputFormatter.digitsOnly
+                          ],
+                          textInputAction: TextInputAction.next,
+                          validator: (v) {
+                            if (!widget.showQuantityField) return null;
+                            if (v == null || v.isEmpty) {
+                              return 'Miktar zorunludur.';
+                            }
+                            final n = int.tryParse(v);
+                            if (n == null || n < 0) {
+                              return 'Geçerli pozitif bir miktar girin.';
+                            }
+                            return null;
+                          }),
+                      const SizedBox(height: 12),
+                    ],
                     TextFormField(
                         controller: _shelfLocationController,
                         decoration: const InputDecoration(

--- a/lib/screens/stok_yonet_page.dart
+++ b/lib/screens/stok_yonet_page.dart
@@ -18,11 +18,13 @@ class StokYonetPage extends StatelessWidget {
         children: <Widget>[
           ActionCard(
             imagePath: 'assets/images/add_stock_icon.png', // KENDİ RESİM YOLUNU GİR
-            title: 'Stok Ekle',
+            title: 'Stok Kartı Oluştur',
             onTap: () {
               // AddEditStockPage'i kök navigator'a push et (BottomNav gizlenecek)
               Navigator.of(context, rootNavigator: true).push(
-                MaterialPageRoute(builder: (context) => const AddEditStockPage()),
+                MaterialPageRoute(
+                    builder: (context) =>
+                        const AddEditStockPage(showQuantityField: false)),
               ).then((_) {
                 // Geri dönüldüğünde bir işlem yapmak istersen
               });


### PR DESCRIPTION
## Summary
- rename "Stok Ekle" action to "Stok Kartı Oluştur"
- hide quantity field when creating a stock card
- keep quantity field visible for normal stock additions

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a4c06708832cb1e082c88bb69e7a