### PR TITLE
Improve stock and customer workflows

### DIFF
--- a/lib/screens/add_edit_customer_page.dart
+++ b/lib/screens/add_edit_customer_page.dart
@@ -107,10 +107,21 @@ class _AddEditCustomerPageState extends State<AddEditCustomerPage> {
       _initialDebtController.text = '0';
       _initialCreditController.text = '0';
     }
+
+    _nameController.addListener(_updatePreview);
+    _customerNumberController.addListener(_updatePreview);
+    _supplierNumberController.addListener(_updatePreview);
+    _phoneController.addListener(_updatePreview);
+    _emailController.addListener(_updatePreview);
   }
 
   @override
   void dispose() {
+    _nameController.removeListener(_updatePreview);
+    _customerNumberController.removeListener(_updatePreview);
+    _supplierNumberController.removeListener(_updatePreview);
+    _phoneController.removeListener(_updatePreview);
+    _emailController.removeListener(_updatePreview);
     _nameController.dispose();
     _customerNumberController.dispose();
     _supplierNumberController.dispose();
@@ -122,6 +133,10 @@ class _AddEditCustomerPageState extends State<AddEditCustomerPage> {
     _initialCreditController.dispose();
     _notesController.dispose();
     super.dispose();
+  }
+
+  void _updatePreview() {
+    if (mounted) setState(() {});
   }
 
   Future<void> _saveCustomer() async {
@@ -370,6 +385,54 @@ class _AddEditCustomerPageState extends State<AddEditCustomerPage> {
     );
   }
 
+  Widget _buildInfoCard() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey[850],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[700]!),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _nameController.text.isEmpty ? 'Yeni Cari' : _nameController.text,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 16,
+            ),
+          ),
+          const SizedBox(height: 8),
+          if (_selectedType == CustomerType.customer &&
+              _customerNumberController.text.isNotEmpty)
+            Text(
+              'Müşteri No: ${_customerNumberController.text}',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          if (_selectedType == CustomerType.supplier &&
+              _supplierNumberController.text.isNotEmpty)
+            Text(
+              'Tedarikçi No: ${_supplierNumberController.text}',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          if (_phoneController.text.isNotEmpty)
+            Text(
+              'Telefon: ${_phoneController.text}',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          if (_emailController.text.isNotEmpty)
+            Text(
+              'E-posta: ${_emailController.text}',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -390,6 +453,8 @@ class _AddEditCustomerPageState extends State<AddEditCustomerPage> {
               children: [
                 // Cari Türü
                 _buildTypeSelector(),
+                const SizedBox(height: 16),
+                _buildInfoCard(),
                 const SizedBox(height: 24),
 
                 // Ad/Firma Adı

--- a/lib/screens/add_edit_stock_page.dart
+++ b/lib/screens/add_edit_stock_page.dart
@@ -13,6 +13,7 @@ import '../models/stock_item.dart';
 import '../models/warehouse_item.dart';
 import '../models/shop_item.dart';
 import '../widgets/corporate_header.dart';
+import './warehouses_shops_page.dart';
 // Eğer barkod/QR tarama butonları aktif edilecekse bu import geri eklenmeli
 // import '../widgets/barcode_scanner_page.dart';
 
@@ -191,6 +192,17 @@ class _AddEditStockPageState extends State<AddEditStockPage> {
     if (!isValid) {
       return;
     }
+    if (_warehouses.isEmpty && _shops.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+                'Kaydetmeden önce en az bir depo veya dükkân oluşturun.'),
+          ),
+        );
+      }
+      return;
+    }
     // _formKey.currentState!.save(); // onSaved kullanmıyorsak gereksiz olabilir
     setState(() {
       _isLoading = true;
@@ -343,7 +355,7 @@ class _AddEditStockPageState extends State<AddEditStockPage> {
                 size: 40, color: Theme.of(context).colorScheme.secondary),
             const SizedBox(height: 10),
             const Text(
-              'Stok ekleyebilmek için lütfen önce bir depo veya dükkan oluşturun.',
+              'Stok eklemek için lütfen önce bir depo veya dükkân oluşturun.',
               textAlign: TextAlign.center,
               style: TextStyle(fontSize: 16),
             ),
@@ -352,11 +364,10 @@ class _AddEditStockPageState extends State<AddEditStockPage> {
               icon: const Icon(Icons.add_business_outlined),
               label: const Text('Depo/Dükkan Yönetimine Git'),
               onPressed: () {
-                Navigator.of(context).pop();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                      content: Text(
-                          'Lütfen alt navigasyondan "Depo/Mağaza" sekmesine gidin.')),
+                Navigator.of(context, rootNavigator: true).push(
+                  MaterialPageRoute(
+                    builder: (_) => const WarehousesShopsPage(),
+                  ),
                 );
               },
             )

--- a/lib/screens/warehouses_shops_page.dart
+++ b/lib/screens/warehouses_shops_page.dart
@@ -16,7 +16,7 @@ class WarehousesShopsPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Depolar / Mağazalar'),
+        title: const Text('Depoları ve Dükkanları Yönet'),
         centerTitle: true,
       ),
       body: SafeArea(


### PR DESCRIPTION
## Summary
- rename warehouses/shops page title
- prevent stock save when no warehouse or shop exists
- link to management page directly from stock form
- show customer info preview card on add customer page

## Testing
- `dart` or `flutter` commands not available

------
https://chatgpt.com/codex/tasks/task_e_6876adde3144832cb3f20e76815cbf53