### PR TITLE
Fix overflow issues in forms

### DIFF
--- a/lib/screens/add_edit_customer_page.dart
+++ b/lib/screens/add_edit_customer_page.dart
@@ -389,7 +389,9 @@ class _AddEditCustomerPageState extends State<AddEditCustomerPage> {
               16.0,
               16.0,
               16.0,
-              16.0 + MediaQuery.of(context).padding.bottom,
+              16.0 +
+                  MediaQuery.of(context).padding.bottom +
+                  MediaQuery.of(context).viewInsets.bottom,
             ),
             child: Column(
               children: [

--- a/lib/screens/add_edit_shop_page.dart
+++ b/lib/screens/add_edit_shop_page.dart
@@ -192,7 +192,14 @@ class _AddEditShopPageState extends State<AddEditShopPage> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding: EdgeInsets.fromLTRB(
+                16.0,
+                16.0,
+                16.0,
+                16.0 +
+                    MediaQuery.of(context).padding.bottom +
+                    MediaQuery.of(context).viewInsets.bottom,
+              ),
               child: Form(
                 key: _formKey,
                 child: ListView(

--- a/lib/screens/add_edit_stock_page.dart
+++ b/lib/screens/add_edit_stock_page.dart
@@ -447,7 +447,9 @@ class _AddEditStockPageState extends State<AddEditStockPage> {
                   16.0,
                   16.0,
                   16.0,
-                  16.0 + MediaQuery.of(context).padding.bottom,
+                  16.0 +
+                      MediaQuery.of(context).padding.bottom +
+                      MediaQuery.of(context).viewInsets.bottom,
                 ),
                 child: Form(
                   key: _formKey,

--- a/lib/screens/add_edit_warehouse_page.dart
+++ b/lib/screens/add_edit_warehouse_page.dart
@@ -210,7 +210,14 @@ class _AddEditWarehousePageState extends State<AddEditWarehousePage> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding: EdgeInsets.fromLTRB(
+                16.0,
+                16.0,
+                16.0,
+                16.0 +
+                    MediaQuery.of(context).padding.bottom +
+                    MediaQuery.of(context).viewInsets.bottom,
+              ),
               child: Form(
                 key: _formKey,
                 child: ListView(

--- a/lib/screens/home_page_with_search.dart
+++ b/lib/screens/home_page_with_search.dart
@@ -80,7 +80,9 @@ class _HomePageWithSearchState extends State<HomePageWithSearch> {
   void _showStyledFlushbar(BuildContext context, String message,
       {Widget? mainButton}) {
     // AMK 1 YAPALIM BAKALIM NE OLACAK
-    final double bottomSafeArea = MediaQuery.of(context).padding.bottom;
+    final mediaQuery = MediaQuery.of(context);
+    final double bottomSafeArea = mediaQuery.padding.bottom;
+    final double viewInsetsBottom = mediaQuery.viewInsets.bottom;
 
     Flushbar(
       messageText: Row(
@@ -104,7 +106,7 @@ class _HomePageWithSearchState extends State<HomePageWithSearch> {
       backgroundColor: Colors.white,
       borderRadius: BorderRadius.circular(30.0),
       margin: EdgeInsets.only(
-        bottom: 1.0,
+        bottom: bottomSafeArea + viewInsetsBottom + 1.0,
         left: 20.0,
         right: 20.0,
       ),
@@ -479,7 +481,9 @@ class _HomePageWithSearchState extends State<HomePageWithSearch> {
                                 : SliverPadding(
                                     padding: EdgeInsets.only(
                                       top: listItemVerticalPadding,
-                                      bottom: _totalBottomClearance + 12.0,
+                                      bottom: _totalBottomClearance +
+                                          MediaQuery.of(context).viewInsets.bottom +
+                                          12.0,
                                     ),
                                     sliver: SliverList(
                                       delegate: SliverChildBuilderDelegate(
@@ -833,10 +837,11 @@ class _HomePageWithSearchState extends State<HomePageWithSearch> {
                         ),
                       ),
                       Positioned(
-                        bottom: 0,
+                        bottom: MediaQuery.of(context).viewInsets.bottom,
                         left: 0,
                         right: 0,
-                        height: _totalBottomClearance,
+                        height:
+                            _totalBottomClearance + MediaQuery.of(context).viewInsets.bottom,
                         child: IgnorePointer(
                           ignoring: true,
                           child: Container(

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -141,7 +141,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       right: 16.0,
                       top: 16.0,
                       // Dinamik bottom padding - overflow çözümü (artırıldı)
-                      bottom: MediaQuery.of(context).padding.bottom + 120.0,
+                      bottom: MediaQuery.of(context).padding.bottom +
+                          MediaQuery.of(context).viewInsets.bottom +
+                          120.0,
                     ),
                     sliver: SliverList(
                       delegate: SliverChildListDelegate([

--- a/lib/screens/stock_list_page.dart
+++ b/lib/screens/stock_list_page.dart
@@ -149,7 +149,7 @@ class _StockListPageState extends State<StockListPage> {
       backgroundColor: Colors.white,
       borderRadius: BorderRadius.circular(30.0),
       margin: EdgeInsets.only(
-        bottom: 1.0,
+        bottom: bottomSafeArea + MediaQuery.of(context).viewInsets.bottom + 1.0,
         left: 20,
         right: 20,
       ),
@@ -261,6 +261,7 @@ class _StockListPageState extends State<StockListPage> {
                         top: listItemVerticalPadding,
                         // Dinamik bottom padding hesaplama - overflow çözümü (artırıldı)
                         bottom: MediaQuery.of(context).padding.bottom +
+                            MediaQuery.of(context).viewInsets.bottom +
                             120.0, // 120px navbar için güvenli alan
                       ),
                       sliver: SliverList(


### PR DESCRIPTION
## Summary
- fix overflow by adding viewInsets to bottom padding for form screens
- adjust settings and stock list page padding and margins
- fix bottom overflow in home page by accounting for keyboard height

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fe7c5f9c832c8e1546b08f6f5082